### PR TITLE
refactor(proxy): remove init bootstrap, rename prompt::mod to prompt::context

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -15,27 +15,7 @@ p6df::modules::proxy::deps() {
 ######################################################################
 #<
 #
-# Function: p6df::modules:::proxy::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-p6df::modules:::proxy::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: str str = p6df::modules::proxy::prompt::mod()
+# Function: str str = p6df::modules::proxy::prompt::context()
 #
 #  Returns:
 #	str - str
@@ -43,7 +23,7 @@ p6df::modules:::proxy::init() {
 #  Environment:	 P6_NL
 #>
 ######################################################################
-p6df::modules::proxy::prompt::mod() {
+p6df::modules::proxy::prompt::context() {
 
   local str
   local pair


### PR DESCRIPTION
## What
Removes the now-unused `p6df::modules:::proxy::init` bootstrap function and renames `p6df::modules::proxy::prompt::mod` to `p6df::modules::proxy::prompt::context`.

## Why
The bootstrap init pattern has been superseded; the rename clarifies the function's role as providing prompt context rather than a generic module entrypoint.

## Test plan
- Source the module and verify proxy environment detection still works via the renamed `prompt::context`

## Dependencies
None